### PR TITLE
APOLLO-25275 - API method to get all document fields

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ classes can be found at [index-stage-plugin-sdk documentation](../index-stage-pl
 Index Stage SDK provides a number of helper classes to simplify unit testing of index stage plugins. 
 To take advantage of the testing framework, plugin project needs to add the following test dependency:
 ```groovy
-testImplementation "com.lucidworks-plugins.index-stage-sdk:index-stage-sdk-test:1.0.0+"
+testImplementation "com.lucidworks-plugins.index-stage-sdk:index-stage-sdk-test:1.+"
 ```
 Once the dependency is added, unit test classes can extend `com.lucidworks.indexing.sdk.test.IndexStageTestBase` and 
 use provided convenience methods to create test documents, index stage configurations and index stage instances. 

--- a/examples/copying-document-stage/build.gradle
+++ b/examples/copying-document-stage/build.gradle
@@ -21,6 +21,11 @@ configurations {
 dependencies {
     // Index Stage SDK dependency is required for all plugins, version must be compatible with your Fusion deployment
     provided "com.lucidworks-plugins.index-stage-sdk:index-stage-plugin-sdk:1.+"
+
+    testImplementation "junit:junit:4.13"
+    testImplementation "org.mockito:mockito-core:3.2.4"
+    testImplementation "org.slf4j:slf4j-simple:1.7.30"
+    testImplementation "com.lucidworks-plugins.index-stage-sdk:index-stage-sdk-test:1.+"
 }
 
 // specific task that allows to create proper plugin zip file

--- a/examples/copying-document-stage/build.gradle
+++ b/examples/copying-document-stage/build.gradle
@@ -20,7 +20,7 @@ configurations {
 
 dependencies {
     // Index Stage SDK dependency is required for all plugins, version must be compatible with your Fusion deployment
-    provided "com.lucidworks-plugins.index-stage-sdk:index-stage-plugin-sdk:1.0.0+"
+    provided "com.lucidworks-plugins.index-stage-sdk:index-stage-plugin-sdk:1.+"
 }
 
 // specific task that allows to create proper plugin zip file
@@ -30,7 +30,7 @@ task assemblePlugin(type: Jar) {
     manifest {
         attributes 'Plugin-Id': 'copying-plugin'
         attributes 'Plugin-Version': "${project.version}"
-        attributes 'Plugin-SDK-Version': '1.0.0'
+        attributes 'Plugin-SDK-Version': '1.1.0'
         attributes 'Plugin-Base-Package': 'com.lucidworks.sample.copying'
     }
     into('lib') {

--- a/examples/copying-document-stage/src/main/java/com/lucidworks/sample/copying/DuplicateDocumentStage.java
+++ b/examples/copying-document-stage/src/main/java/com/lucidworks/sample/copying/DuplicateDocumentStage.java
@@ -23,7 +23,7 @@ public class DuplicateDocumentStage extends IndexStageBase<DuplicateDocumentConf
   public void process(Document original, Context context, Consumer<Document> output) {
     // Create a copy of a document and push it
     Document copy = newDocument(original.getId() + "-copy");
-    for (Document.Field originalField : original.fields()) {
+    for (Document.Field originalField : original.allFields()) {
       copy.field(originalField.getName()).set(originalField.get());
     }
     copy.field(COPY_MARK_FIELD_NAME).set(Boolean.TRUE);

--- a/examples/copying-document-stage/src/test/java/com/lucidworks/sample/copying/DuplicateDocumentStageTest.java
+++ b/examples/copying-document-stage/src/test/java/com/lucidworks/sample/copying/DuplicateDocumentStageTest.java
@@ -1,0 +1,61 @@
+package com.lucidworks.sample.copying;
+
+
+import com.lucidworks.indexing.api.Document;
+import com.lucidworks.indexing.api.Types;
+import com.lucidworks.indexing.api.fusion.Documents;
+import com.lucidworks.indexing.sdk.test.IndexStageTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class DuplicateDocumentStageTest extends IndexStageTestBase<DuplicateDocumentConfig> {
+
+  @Mock
+  protected Documents documents;
+
+  @Before
+  public void before() {
+    when(fusion.documents()).thenReturn(documents);
+    when(documents.newDocument(anyString())).thenAnswer(invocation -> newDocument(invocation.getArgument(0)));
+  }
+
+  @Test
+  public void process() throws Exception {
+    DuplicateDocumentConfig stageConfig = newConfig(DuplicateDocumentConfig.class);
+
+    Document document = newDocument("doc1");
+    document.field("stringField").set("test string").type(Types.STRING);
+    document.field("_lw_internalField").set("internal string").type(Types.STRING);
+
+    List<Document> result = new ArrayList<>();
+
+    DuplicateDocumentStage stage = createStage(DuplicateDocumentStage.class, stageConfig);
+    stage.process(document, null, result::add);
+
+    assertEquals(2, result.size());
+
+    Document copy = result.get(0);
+    assertEquals(2, copy.fields().size());
+    assertEquals(3, copy.allFields().size());
+    assertEquals("doc1-copy", copy.getId());
+    assertEquals("test string", copy.field("stringField").getFirst());
+    assertEquals("internal string", copy.field("_lw_internalField").getFirst());
+    assertEquals(Boolean.TRUE, copy.field("is_copy").getFirst());
+
+    Document original = result.get(1);
+    assertEquals(2, original.fields().size());
+    assertEquals(3, original.allFields().size());
+    assertEquals("doc1", original.getId());
+    assertEquals("test string", original.field("stringField").getFirst());
+    assertEquals("internal string", original.field("_lw_internalField").getFirst());
+    assertEquals(Boolean.FALSE, original.field("is_copy").getFirst());
+  }
+}

--- a/examples/sample-plugin-stage/build.gradle
+++ b/examples/sample-plugin-stage/build.gradle
@@ -20,7 +20,7 @@ configurations {
 
 dependencies {
     // Index Stage SDK dependency is required for all plugins, version must be compatible with your Fusion deployment
-    provided "com.lucidworks-plugins.index-stage-sdk:index-stage-plugin-sdk:1.0.0+"
+    provided "com.lucidworks-plugins.index-stage-sdk:index-stage-plugin-sdk:1.+"
 
     // prometheus client dependency is only needed if plugins are publishing custom metrics via Fusion
     provided 'io.prometheus:simpleclient_dropwizard:0.7.0'
@@ -30,7 +30,7 @@ dependencies {
     testImplementation "junit:junit:4.13"
     testImplementation "org.mockito:mockito-core:3.2.4"
     testImplementation "org.slf4j:slf4j-simple:1.7.30"
-    testImplementation "com.lucidworks-plugins.index-stage-sdk:index-stage-sdk-test:1.0.0+"
+    testImplementation "com.lucidworks-plugins.index-stage-sdk:index-stage-sdk-test:1.+"
 }
 
 // use this gradle task to assemble plugin zip file
@@ -40,7 +40,7 @@ task assemblePlugin(type: Jar) {
     manifest {
         attributes 'Plugin-Id': 'sample-plugin'
         attributes 'Plugin-Version': '0.0.1'
-        attributes 'Plugin-SDK-Version': '1.0.0'
+        attributes 'Plugin-SDK-Version': '1.1.0'
         attributes 'Plugin-Base-Package': 'com.lucidworks.sample'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 #
 group=com.lucidworks-plugins
-release.scope=major
+release.scope=patch
 #
 gradlePluginVersion=3.0.1
 #

--- a/index-stage-plugin-sdk/README.md
+++ b/index-stage-plugin-sdk/README.md
@@ -15,7 +15,7 @@ Example of custom META-INF/MANIFEST.MF file:
 ```
 Manifest-Version: 1.0
 Plugin-Id: sample-plugin
-Plugin-SDK-Version: 1.0.0
+Plugin-SDK-Version: 1.1.0
 Plugin-Base-Package: com.lucidworks.sample
 Plugin-Version: 0.0.1
 

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
@@ -81,11 +81,18 @@ public interface Document {
   <T> Field<T> field(String fieldName, Class<T> fieldClass);
 
   /**
-   * Get all fields document contains.
+   * Get all fields document contains, excluding those that are reserved for internal use
    *
    * @return Set of document fields
    */
   Set<Field<Object>> fields();
+
+  /**
+   * Get all fields document contains, including those that are reserved for internal use.
+   *
+   * @return Set of document fields
+   */
+  Set<Field<Object>> allFields();
 
   /**
    * Representation of single field in document. Fields can be multivalued

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
@@ -72,9 +72,10 @@ public class TestDocument implements Document {
 
   @Override
   public Set<Field<Object>> fields() {
-    return fields.entrySet().stream()
+    return new HashSet(fields.entrySet().stream()
         .filter(e -> !e.getKey().startsWith("_lw_"))
-        .map(Map.Entry::getValue).collect(Collectors.toSet());
+        .map(Map.Entry::getValue)
+        .collect(Collectors.toSet()));
   }
 
   @Override

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
@@ -75,6 +75,11 @@ public class TestDocument implements Document {
     return new HashSet(fields.values());
   }
 
+  @Override
+  public Set<Field<Object>> allFields() {
+    return new HashSet(fields.values());
+  }
+
   static class TestField<T> implements Field<T> {
 
     private String name;

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
@@ -72,7 +72,9 @@ public class TestDocument implements Document {
 
   @Override
   public Set<Field<Object>> fields() {
-    return new HashSet(fields.values());
+    return fields.entrySet().stream()
+        .filter(e -> !e.getKey().startsWith("_lw_"))
+        .map(Map.Entry::getValue).collect(Collectors.toSet());
   }
 
   @Override


### PR DESCRIPTION
# Tl;dr
API method to get all document fields.

# Details
Adding `Document.allFields()` method which returns all document fields including internal fields starting with `_lw_` prefix.

# How to verify
Call `Document.allFields()` method, in addition to regular fields it should also return all internal fields.
