### PR TITLE
Add support for field hints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 org.gradle.parallel=false
 #
 group=com.lucidworks-plugins
-release.scope=patch
+release.scope=minor
 #
 gradlePluginVersion=3.0.1
 #

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
@@ -177,5 +177,20 @@ public interface Document {
      * @return This field
      */
     Field<T> map(UnaryOperator<T> mapper);
+
+    /**
+     * Add hint value to the field.
+     *
+     * @param hint Hint value
+     * @return This field
+     */
+    Field<T> hint(String... hint);
+
+    /**
+     * Get all hints for this field.
+     *
+     * @return Field hints
+     */
+    Set<String> getHints();
   }
 }

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
@@ -156,7 +156,7 @@ public interface Document {
     Field<T> type(Types type);
 
     /**
-     * Set atomic update modifier hint. This will tell Fusion what atomic update operation to apply to the field.
+     * Set atomic update modifier hint. This will tell Fusion what atomic update operation to apply to the field, if any.
      *
      * @param operation Operation modifier value to be set for the field
      * @return This field

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Document.java
@@ -156,6 +156,14 @@ public interface Document {
     Field<T> type(Types type);
 
     /**
+     * Set atomic update modifier hint. This will tell Fusion what atomic update operation to apply to the field.
+     *
+     * @param operation Operation modifier value to be set for the field
+     * @return This field
+     */
+    Field<T> operation(Operations operation);
+
+    /**
      * Set multivalued field hint. This will tell Fusion to use multivalued Solr field type for this field
      * when saving document to collection.
      *

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Operations.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Operations.java
@@ -1,0 +1,24 @@
+package com.lucidworks.indexing.api;
+
+/**
+ * Atomic update operation modifier hints.
+ */
+public enum Operations {
+
+  SET("modifier_set"),   // Set or replace the field value(s) with the specified value(s), or remove the values if 'null' or empty list is specified as the new value
+  ADD("modifier_add"),   // Adds the specified values to a multiValued field
+  ADD_DISTINCT("modifier_add-distinct"), // Adds the specified values to a multiValued field, only if not already present
+  REMOVE("modifier_remove"), //Removes (all occurrences of) the specified values from a multiValued field
+  REMOVEREGEX("modifier_removeregex"), // Removes all occurrences of the specified regex from a multiValued field
+  INC("modifier_inc"); // Increments a numeric value by a specific amount
+
+  private final String hint;
+
+  Operations(String hint) {
+    this.hint = hint;
+  }
+
+  public String getHint() {
+    return hint;
+  }
+}

--- a/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Types.java
+++ b/index-stage-plugin-sdk/src/main/java/com/lucidworks/indexing/api/Types.java
@@ -16,7 +16,7 @@ public enum Types {
   BINARY("type_binary"),
   LOCATION("type_location");
 
-  private String hint;
+  private final String hint;
 
   Types(String hint) {
     this.hint = hint;

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
@@ -1,6 +1,7 @@
 package com.lucidworks.indexing.sdk.test;
 
 import com.lucidworks.indexing.api.Document;
+import com.lucidworks.indexing.api.Operations;
 import com.lucidworks.indexing.api.Types;
 
 import java.util.ArrayList;
@@ -135,6 +136,12 @@ public class TestDocument implements Document {
     @Override
     public Field<T> type(Types type) {
       hints.add(type.getHint());
+      return this;
+    }
+
+    @Override
+    public Field<T> operation(Operations operation) {
+      hints.add(operation.getHint());
       return this;
     }
 

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/TestDocument.java
@@ -4,6 +4,7 @@ import com.lucidworks.indexing.api.Document;
 import com.lucidworks.indexing.api.Types;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -87,7 +88,7 @@ public class TestDocument implements Document {
 
     private String name;
     private List<T> values = new ArrayList<>();
-    private Set<Types> hints = new HashSet<>();
+    private Set<String> hints = new HashSet<>();
     private boolean multivalued = false;
 
     public TestField(String name) {
@@ -133,7 +134,7 @@ public class TestDocument implements Document {
 
     @Override
     public Field<T> type(Types type) {
-      hints.add(type);
+      hints.add(type.getHint());
       return this;
     }
 
@@ -154,12 +155,19 @@ public class TestDocument implements Document {
       return this;
     }
 
-    public boolean isMultivalued() {
-      return multivalued;
+    @Override
+    public Field<T> hint(String... hint) {
+      hints.addAll(Arrays.asList(hint));
+      return this;
     }
 
-    public Set<Types> getHints() {
+    @Override
+    public Set<String> getHints() {
       return hints;
+    }
+
+    public boolean isMultivalued() {
+      return multivalued;
     }
   }
 }


### PR DESCRIPTION
# Tl;dr
Add support for field hints.

# Details
Add API methods for better support of document field hints:
 * `Field<T> hint(String... hint)` - add hint(s) to a field
 * `Set<String> getHints()` - get hints set for a field

