### PR TITLE
APOLLO-27754 Updating example READMEs

### DIFF
--- a/examples/copying-document-stage/README.md
+++ b/examples/copying-document-stage/README.md
@@ -12,7 +12,7 @@ This will create a plugin zip file (with required manifest file) within the ```b
 You can deploy your plugin with UI ("Blobs" section) or using the curl command:
 
 ```bash
-curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @copying-document-stage-0.0.1.zip https://[fusion url]/api/index-stages-plugins
+curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @copying-document-stage-0.0.1.zip https://[fusion url]/api/index-stage-plugins
 ```
 
 After correct deployment new stages should be visible on the `Stages` list in the Fusion UI

--- a/examples/copying-document-stage/README.md
+++ b/examples/copying-document-stage/README.md
@@ -5,14 +5,14 @@ This is also a demonstration how single stage can emit multiple documents while 
 
 
 # Build
-To create a plugin call ```./gradlew -p examples/copying-plugin-stage assemblePlugin``` in the main folder.
+To create a plugin call ```./gradlew -p examples/copying-document-stage assemblePlugin``` in the main folder.
 This will create a plugin zip file (with required manifest file) within the ```build/libs``` folder
 
 # Deploy
 You can deploy your plugin with UI ("Blobs" section) or using the curl command:
 
 ```bash
-curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @copying-plugin-stage-0.0.1.zip https://[fusion url]/api/index-stages/plugins
+curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @copying-document-stage-0.0.1.zip https://[fusion url]/api/index-stages-plugins
 ```
 
 After correct deployment new stages should be visible on the `Stages` list in the Fusion UI

--- a/examples/sample-plugin-stage/README.md
+++ b/examples/sample-plugin-stage/README.md
@@ -22,7 +22,7 @@ You can deploy the example plugins via Fusion UI ("Blobs" section) or by using `
 
 Alternatively you can also deploy plugin via Fusion REST API by using `curl`:
 ```bash
-curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @sample-plugin-stage-0.0.1.zip https://[fusion url]/api/index-stages-plugins
+curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @sample-plugin-stage-0.0.1.zip https://[fusion url]/api/index-stage-plugins
 ```
 
 After successful deployment new stages should be visible in the `Stages` list in the Fusion Index Pipelines UI.

--- a/examples/sample-plugin-stage/README.md
+++ b/examples/sample-plugin-stage/README.md
@@ -22,7 +22,7 @@ You can deploy the example plugins via Fusion UI ("Blobs" section) or by using `
 
 Alternatively you can also deploy plugin via Fusion REST API by using `curl`:
 ```bash
-curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @sample-plugin-stage-0.0.1.zip https://[fusion url]/api/index-stages/plugins
+curl -u [user]:[password] -X PUT -H "Content-Type:application/zip" --data-binary @sample-plugin-stage-0.0.1.zip https://[fusion url]/api/index-stages-plugins
 ```
 
 After successful deployment new stages should be visible in the `Stages` list in the Fusion Index Pipelines UI.


### PR DESCRIPTION
# Tl;dr
Updates the example READMEs

# Details
1. Corrects the name of the plugin referred to in the `copying-document-stage` example plugin.
2. Corrects the API endpoint for uploading the plugin