### PR TITLE
Escape '>' in javadoc

### DIFF
--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
@@ -71,7 +71,7 @@ public abstract class IndexStageTestBase<C extends IndexStageConfig> {
    * The callback can be used to setup return values for the config mock, e.g.
    *
    * <pre>
-   *   SimpleStageConfig stageConfig = newConfig(SimpleStageConfig.class, config -> {
+   *   SimpleStageConfig stageConfig = newConfig(SimpleStageConfig.class, config -&gt; {
    *     when(config.field()).thenReturn("field_name");
    *     when(config.text()).thenReturn("text_value");
    *   });


### PR DESCRIPTION
# Tl;dr
Escape '>' character in javadoc.

# Details
Escape '>' character in javadoc to fix error during javadoc generation.

