### PR TITLE
Mock Fusion instance correctly in IndexStageTestBase

### DIFF
--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
@@ -44,8 +44,8 @@ public abstract class IndexStageTestBase<C extends IndexStageConfig> {
 
   private void mockDocumentsInFusion() {
     Documents documents = Mockito.mock(Documents.class);
-    Mockito.when(documents.newDocument()).thenReturn(new TestDocument(null));
-    Mockito.when(documents.newDocument(any())).then(invocation -> new TestDocument(invocation.getArgument(0)));
+    Mockito.when(documents.newDocument()).then(invocation -> newDocument());
+    Mockito.when(documents.newDocument(any())).then(invocation -> newDocument(invocation.getArgument(0)));
     Mockito.when(fusion.documents()).thenReturn(documents);
   }
 

--- a/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
+++ b/index-stage-sdk-test/src/main/java/com/lucidworks/indexing/sdk/test/IndexStageTestBase.java
@@ -2,6 +2,7 @@ package com.lucidworks.indexing.sdk.test;
 
 import com.lucidworks.indexing.api.Document;
 import com.lucidworks.indexing.api.IndexStage;
+import com.lucidworks.indexing.api.fusion.Documents;
 import com.lucidworks.indexing.api.fusion.Fusion;
 import com.lucidworks.indexing.config.IndexStageConfig;
 import org.junit.runner.RunWith;
@@ -10,6 +11,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Base class for index stage unit tests.
@@ -31,10 +34,19 @@ public abstract class IndexStageTestBase<C extends IndexStageConfig> {
    * @throws ReflectiveOperationException when unable to instantiate stage class using default no param constructor
    */
   public <S extends IndexStage<C>> S createStage(Class<S> stageClass, C config) throws ReflectiveOperationException {
+    mockDocumentsInFusion();
+
     S stage = stageClass.getDeclaredConstructor().newInstance();
     stage.init(config, fusion);
 
     return stage;
+  }
+
+  private void mockDocumentsInFusion() {
+    Documents documents = Mockito.mock(Documents.class);
+    Mockito.when(documents.newDocument()).thenReturn(new TestDocument(null));
+    Mockito.when(documents.newDocument(any())).then(invocation -> new TestDocument(invocation.getArgument(0)));
+    Mockito.when(fusion.documents()).thenReturn(documents);
   }
 
   /**


### PR DESCRIPTION
# Tl;dr

Mock Fusion instance correctly in IndexStageTestBase

# Details

Previously, if the `IndexStage` you were testing contained a call to `IndexStage::newDocument`, the unit test would fail because of an NPE because the tested `IndexStage` environment tries to create a document, but it cannot because the behaviour of the `Fusion` instance that's injected into the `IndexStage` isn't mocked correctly.

This PR fixes that behaviour and lets IndexStage instances run newDocuments, but it runs the IndexStageTestBase::newDocument in the background.

# How to verify

Let's suppose you have an IndexStage that looks something like this:

```java
public class MyStage extends IndexStageBase<MyStageConfig> {
// [...]
    @Override
    public void process(Document document, Context context, Consumer<Document> output) {
       Document document = newDocument();
       output.accept(document);
    }
// [...]
}

```

And the test looking like this:

```java
public class MyStageTest extends IndexStageTestBase<MyStageConfig> {
// [...]
 @Test
    public void testWhenValidUrlIsProvidedDocumentShouldBeFed() {
         MyStageConfig conf = newConfig(MyStageConfig.class, config -> {
             // [...]
        }); 

        MyStage underTest = createStage(MyStage.class, conf);

        underTest.process(doc, null, System.out::println);
    }
// [...]
}
```

It would end up in a NPE in the current version, but with this PR it should print the new document.