### PR TITLE
DEVX-424: Test official sonar-scanner-cli image with pipeline updates

### DIFF
--- a/jenkins/build.groovy
+++ b/jenkins/build.groovy
@@ -1,4 +1,4 @@
-@Library("one-platform-jenkins")_
+@Library("one-platform-jenkins@DEVX-424-use-official-sonar-scanner-image")_
 
 properties([
         [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],


### PR DESCRIPTION
# Tl;dr
This pull request makes a minor update to the Jenkins pipeline configuration by specifying a particular branch of the shared library to use.

- Jenkins pipeline now uses the `one-platform-jenkins@DEVX-424-use-official-sonar-scanner-image` branch instead of the default branch for the shared library in `build.groovy`.
<!-- Insert brief description of this PR. This will become the commit body once merged -->

# Details
<!-- As much detail as you think is necessary -->

<!-- Be sure to link to any relevant Slack discussions or channels -->

# How to verify
<!-- For bug fixes, how to verify the fix; for new features, steps on how to see it in action -->
